### PR TITLE
Fix body to be stringified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,8 @@ export default class Snuffles {
     const { query, ...requestOptions } = fullOptions
 
     if (requestOptions.body) {
-      requestOptions.body = changeCaseObject.snakeCase(requestOptions.body)
+      const snakeCasedBody = changeCaseObject.snakeCase(requestOptions.body)
+      requestOptions.body = JSON.stringify(snakeCasedBody)
     }
 
     return fetch(`${url}${queryString}`, {

--- a/src/test.js
+++ b/src/test.js
@@ -148,19 +148,14 @@ describe('snuffles', () => {
           }
         }
 
-        const transformedOptions = {
-          body: {
-            user_name: 'Sirius',
-            still_alive: false
-          }
-        }
+        const expectedBody = { user_name: 'Sirius', still_alive: false }
 
         global.fetch.mockResponseOnce(JSON.stringify({}))
         api.request(requestPath, options)
-        expect(global.fetch).toHaveBeenCalledWith(
-          requestUrl,
-          expect.objectContaining(transformedOptions)
-        )
+        const jsonRequestBody = JSON.parse(global.fetch.mock.calls[0][1].body)
+
+        expect(jsonRequestBody).toEqual(expectedBody)
+        expect(global.fetch).toHaveBeenCalledWith(requestUrl, expect.anything())
       })
 
       describe('querystring', () => {


### PR DESCRIPTION
The `body` of a request needs to be sent as a string, so I wrapped `JSON.stringify` around the request body.