### PR TITLE
Add response to error object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,12 @@ export default class Snuffles {
       ...requestOptions
     })
       .then(res => {
-        if (!res.ok) throw new Error('API Response was not ok', res)
+        if (!res.ok) {
+          const error = new Error('API response was not ok.')
+          error.response = res
+          throw error
+        }
+
         return res
       })
       .then(res => res.json())


### PR DESCRIPTION
According to the [MDN Spec for Error](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Error), the second parameter in the error constructor is for a filename. I changed it to add the response to the error object. This way someone can inspect the response in a catch:

```js
.catch(err => {
  console.log(err.response)
})
```