### PR TITLE
downgrade query-string dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   "dependencies": {
     "deepmerge": "2.2.1",
     "change-case-object": "2.0.0",
-    "query-string": "6.2.0"
+    "query-string": "4.1.0"
   }
 }


### PR DESCRIPTION
- query-string 6.2.0 uses strict-uri-encode@^2.0.0 which is not
transpiled and therefore needs a polyfill to run