### PR TITLE
Allow definition of body formatting in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 At its core, Snuffles is just a very slim wrapper around the [native `fetch` function](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch). It allows for setting a base url and default options for your request, provides some wrappers around some of the more frequently used HTTP methods and takes care of all casing. You send camelCased objects in, you get camelCased objects out.
 
-
 ## Installation
 
 ```bash
@@ -31,34 +30,41 @@ export default function myApiWrapper() {
   }
 
   const api = new Snuffles('http://base-url.tld', defaultOptions)
-  
+
   const user = api.get('/user')
 }
 ```
 
 To create a new instance of Snuffles:
+
 ```js
-const api = new Snuffles(baseUrl[, defaultOptions])
+const api = new Snuffles(baseUrl[, defaultOptions, bodyFormat])
 ```
-* __`baseUrl`__: The base url of the API you want to make requests agains
-* __`defaultOptions`__ (_optional_): An Object, containing a set of default options you want to sent in every request, e.g. headers for authentication
+
+- **`baseUrl`**: The base url of the API you want to make requests agains
+- **`defaultOptions`** (_optional_): An Object, containing a set of default options you want to sent in every request, e.g. headers for authentication
+- **`bodyForma`** (_optional_): A string representing the format in which a request body should be sent out. Accepts `SNAKE_CASE` (default), `CAMEL_CASE` and `PARAM_CASE`.
 
 As of now, Snuffles has wrappers for 5 request methods:
-* `get(path[, options])`
-* `post(path[, options])`
-* `put(path[, options])`
-* `patch(path[, options])`
-* `delete(path[, options])`
+
+- `get(path[, options])`
+- `post(path[, options])`
+- `put(path[, options])`
+- `patch(path[, options])`
+- `delete(path[, options])`
 
 Where
-* __`path`__: the path you want that specific request to go to
-* __`options`__ (_optional_): An Object containing a set of options you want to merge with the base options on this specific request. Options passed to the wrapper functions are deep-merged, but will override identical keys.
+
+- **`path`**: the path you want that specific request to go to
+- **`options`** (_optional_): An Object containing a set of options you want to merge with the base options on this specific request. Options passed to the wrapper functions are deep-merged, but will override identical keys.
 
 ### Options
-Snuffles accepts all options that fetch accepts as its `init` parameter ([docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)). In fact, snuffles does not validate the options that are passed at all.  
+
+Snuffles accepts all options that fetch accepts as its `init` parameter ([docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)). In fact, snuffles does not validate the options that are passed at all.
 
 ### Using querystrings
-Snuffles does support the setting of querystrings via its options parameter. You can pass in a `query` object with the desired key-value-pairs.  
+
+Snuffles does support the setting of querystrings via its options parameter. You can pass in a `query` object with the desired key-value-pairs.
 For example:
 
 ```js
@@ -66,8 +72,8 @@ const api = new Snuffles('http://base-url.tld')
 
 const options = {
   query: {
-    'name': 'sirius',
-    'animal': 'dog'
+    name: 'sirius',
+    animal: 'dog'
   }
 }
 
@@ -77,12 +83,14 @@ const user = api.get('/user', options)
 ```
 
 ### Casing
+
 Snuffles will take care of transforming the casing of response and request
 bodies, so that you can pass in a camelCased object as a request body (passed
 via `options.body`) and get out the response body as a camelCased object as
 well.
 
 #### Response bodies
+
 Assuming `GET https://your-api/users/1` would return a response with a body of
 
 ```json
@@ -91,6 +99,7 @@ Assuming `GET https://your-api/users/1` would return a response with a body of
   "paid_user": false
 }
 ```
+
 If you make this request with snuffles, it would look like
 
 ```js
@@ -113,8 +122,8 @@ const api = new Snuffles('http://base-url.tld')
 
 const options = {
   body: {
-    'userName': 'sirius',
-    'paidUser': true
+    userName: 'sirius',
+    paidUser: true
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default function myApiWrapper() {
 To create a new instance of Snuffles:
 
 ```js
-const api = new Snuffles(baseUrl[, defaultRequestOptions, bodyKeyCase])
+const api = new Snuffles(baseUrl[, defaultRequestOptions, metaOptions])
 ```
 
 - **`baseUrl`**: The base url of the API you want to make requests agains

--- a/README.md
+++ b/README.md
@@ -23,13 +23,21 @@ npm install --save snuffles
 import Snuffles from 'snuffles'
 
 export default function myApiWrapper() {
-  const defaultOptions = {
+  const defaultRequestOptions = {
     headers: {
       'X-AUTH-TOKEN': 'my-secret-token'
     }
   }
 
-  const api = new Snuffles('http://base-url.tld', defaultOptions)
+  const metaOptions = {
+    bodyKeyCase: 'CAMEL_CASE'
+  }
+
+  const api = new Snuffles(
+    'http://base-url.tld',
+    defaultRequestOptions,
+    metaOptions
+  )
 
   const user = api.get('/user')
 }
@@ -38,12 +46,32 @@ export default function myApiWrapper() {
 To create a new instance of Snuffles:
 
 ```js
-const api = new Snuffles(baseUrl[, defaultOptions, bodyKeyCase])
+const api = new Snuffles(baseUrl[, defaultRequestOptions, bodyKeyCase])
 ```
 
 - **`baseUrl`**: The base url of the API you want to make requests agains
-- **`defaultOptions`** (_optional_): An Object, containing a set of default options you want to sent in every request, e.g. headers for authentication
-- **`bodyKeyCase`** (_optional_): A string representing the casing in which a request body keys should be sent out. Accepts `SNAKE_CASE` (default), `CAMEL_CASE` and `PARAM_CASE`.
+- **`defaultRequestOptions`** (_optional_): An Object, containing a set of default options you want to sent in every request, e.g. headers for authentication
+- **`metaOptions`** (_optional_): An object containing meta configuration for Snuffles. For possible options, please refer to the list below
+
+### Default Request Options
+
+Snuffles accepts all options that fetch accepts as its `init` parameter ([docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)). In fact, snuffles does not validate the options that are passed at all.
+
+### Meta Options
+
+The `metaOptions` object accepts the following configureations:
+
+- **`bodyKeyCase`**: A string defining which casing the keys of a request body for **outgoing requests** should have. Can be either of `SNAKE_CASE`, `CAMEL_CASE` or `PARAM_CASE`.
+
+If no object is passed for `metaOptions`, the following defaul configuration will be used:
+
+```javascript
+{
+  bodyKeyCase: 'SNAKE_CASE'
+}
+```
+
+### Supported HTTP Methods
 
 As of now, Snuffles has wrappers for 5 request methods:
 
@@ -57,10 +85,6 @@ Where
 
 - **`path`**: the path you want that specific request to go to
 - **`options`** (_optional_): An Object containing a set of options you want to merge with the base options on this specific request. Options passed to the wrapper functions are deep-merged, but will override identical keys.
-
-### Options
-
-Snuffles accepts all options that fetch accepts as its `init` parameter ([docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)). In fact, snuffles does not validate the options that are passed at all.
 
 ### Using querystrings
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ export default function myApiWrapper() {
 To create a new instance of Snuffles:
 
 ```js
-const api = new Snuffles(baseUrl[, defaultOptions, bodyFormat])
+const api = new Snuffles(baseUrl[, defaultOptions, bodyKeyCase])
 ```
 
 - **`baseUrl`**: The base url of the API you want to make requests agains
 - **`defaultOptions`** (_optional_): An Object, containing a set of default options you want to sent in every request, e.g. headers for authentication
-- **`bodyForma`** (_optional_): A string representing the format in which a request body should be sent out. Accepts `SNAKE_CASE` (default), `CAMEL_CASE` and `PARAM_CASE`.
+- **`bodyKeyCase`** (_optional_): A string representing the casing in which a request body keys should be sent out. Accepts `SNAKE_CASE` (default), `CAMEL_CASE` and `PARAM_CASE`.
 
 As of now, Snuffles has wrappers for 5 request methods:
 

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -1,0 +1,28 @@
+import changeCaseObject from 'change-case-object'
+
+const BODY_KEY_CASE_OPTIONS = {
+  SNAKE_CASE: changeCaseObject.snakeCase,
+  CAMEL_CASE: changeCaseObject.camelCase,
+  PARAM_CASE: changeCaseObject.paramCase
+}
+
+export default class MetaOptions {
+  constructor(options) {
+    if (!options.bodyKeyCase || !this.isValidBodyKeyCase(options.bodyKeyCase)) {
+      throw new Error('This body key formatting option is not allowed.')
+    }
+
+    this.bodyKeyCase = options.bodyKeyCase
+  }
+
+  isValidBodyKeyCase(bodyKeyCase) {
+    if (Object.keys(BODY_KEY_CASE_OPTIONS).indexOf(bodyKeyCase) < 0) {
+      return false
+    }
+    return true
+  }
+
+  getBodyKeyConverter() {
+    return BODY_KEY_CASE_OPTIONS[this.bodyKeyCase]
+  }
+}

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -16,7 +16,7 @@ export default class MetaOptions {
   }
 
   isValidBodyKeyCase(bodyKeyCase) {
-    return Object.keys(BODY_KEY_CASE_OPTIONS).indexOf(bodyKeyCase) >= 0
+    return Object.keys(BODY_KEY_CASE_OPTIONS).includes(bodyKeyCase)
   }
 
   getBodyKeyConverter() {

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -16,10 +16,7 @@ export default class MetaOptions {
   }
 
   isValidBodyKeyCase(bodyKeyCase) {
-    if (Object.keys(BODY_KEY_CASE_OPTIONS).indexOf(bodyKeyCase) < 0) {
-      return false
-    }
-    return true
+    return Object.keys(BODY_KEY_CASE_OPTIONS).indexOf(bodyKeyCase) >= 0
   }
 
   getBodyKeyConverter() {

--- a/src/__tests__/MetaOptions.js
+++ b/src/__tests__/MetaOptions.js
@@ -1,0 +1,24 @@
+import MetaOptions from '../MetaOptions'
+
+describe('MetaOptions', () => {
+  describe('Initialisation', () => {
+    it('is valid with a valida options object', () => {
+      const options = { bodyKeyCase: 'SNAKE_CASE' }
+      const metaOptions = new MetaOptions(options)
+      expect(metaOptions).toBeTruthy()
+    })
+
+    it('throws an error if no options are passed', () => {
+      expect(() => new MetaOptions()).toThrow()
+    })
+
+    it('throws an error if bodyKeyCase is not present in the options', () => {
+      expect(() => new MetaOptions({})).toThrow()
+    })
+
+    it('throws an error if bodyKeyCase is not valid', () => {
+      const options = { bodyKeyCase: 'INVALID' }
+      expect(() => new MetaOptions(options)).toThrow()
+    })
+  })
+})

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,4 +1,4 @@
-import Snuffles from './index.js'
+import Snuffles from '../index.js'
 global.fetch = require('jest-fetch-mock')
 
 const baseUrl = 'http://example.com'
@@ -15,31 +15,32 @@ describe('snuffles', () => {
       expect(() => new Snuffles()).toThrow()
     })
 
-    it('is valid without defaultOptions', () => {
+    it('is valid without defaultRequestOptions', () => {
       const api = new Snuffles(baseUrl)
       expect(api).toBeTruthy()
     })
 
     it('sets the baseUrl and default options', () => {
-      const defaultOptions = {
+      const defaultRequestOptions = {
         headers: {
           'X-AUTH-TOKEN': 'secret'
         }
       }
 
-      const api = new Snuffles(baseUrl, defaultOptions)
+      const api = new Snuffles(baseUrl, defaultRequestOptions)
       expect(api.baseUrl).toEqual(baseUrl)
-      expect(api.defaultOptions).toEqual(defaultOptions)
+      expect(api.defaultRequestOptions).toEqual(defaultRequestOptions)
     })
 
     it('sets the default body formatting', () => {
       const api = new Snuffles(baseUrl)
-      expect(api.bodyKeyCase).toEqual('SNAKE_CASE')
+      expect(api.metaOptions.bodyKeyCase).toEqual('SNAKE_CASE')
     })
 
     it('sets the passed body formatting', () => {
-      const api = new Snuffles(baseUrl, {}, 'CAMEL_CASE')
-      expect(api.bodyKeyCase).toEqual('CAMEL_CASE')
+      const metaOptions = { bodyKeyCase: 'CAMEL_CASE' }
+      const api = new Snuffles(baseUrl, {}, metaOptions)
+      expect(api.metaOptions.bodyKeyCase).toEqual('CAMEL_CASE')
     })
 
     it('does not set a forbidden body formatting', () => {
@@ -81,7 +82,7 @@ describe('snuffles', () => {
         expect(global.fetch).toHaveBeenCalledWith(requestUrl, expect.anything())
       })
 
-      it('merges the passed options with the defaultOptions', () => {
+      it('merges the passed options with the defaultRequestOptions', () => {
         const options = {
           headers: {
             'X-ALLOW-FRAME': 'SAMEORIGIN'

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import merge from 'deepmerge'
 
 const ALLOWED_REQUEST_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
 
-const BODY_FORMATTING_OPTIONS = {
+const BODY_KEY_CASE_OPTIONS = {
   SNAKE_CASE: 'SNAKE_CASE',
   CAMEL_CASE: 'CAMEL_CASE',
   PARAM_CASE: 'PARAM_CASE'
@@ -14,19 +14,19 @@ export default class Snuffles {
   constructor(
     baseUrl,
     defaultOptions = {},
-    bodyFormat = BODY_FORMATTING_OPTIONS.SNAKE_CASE
+    bodyKeyCase = BODY_KEY_CASE_OPTIONS.SNAKE_CASE
   ) {
     if (!baseUrl) {
       throw new Error('baseUrl has to be set')
     }
 
-    if (Object.values(BODY_FORMATTING_OPTIONS).indexOf(bodyFormat) < 0) {
+    if (Object.values(BODY_KEY_CASE_OPTIONS).indexOf(bodyKeyCase) < 0) {
       throw new Error('This formatting option is not allowed.')
     }
 
     this.baseUrl = baseUrl
     this.defaultOptions = defaultOptions
-    this.bodyFormat = bodyFormat
+    this.bodyKeyCase = bodyKeyCase
   }
 
   get(path, options = {}) {
@@ -98,12 +98,12 @@ export default class Snuffles {
   }
 
   formatBody(body) {
-    switch (this.bodyFormat) {
-      case BODY_FORMATTING_OPTIONS.CAMEL_CASE:
+    switch (this.bodyKeyCase) {
+      case BODY_KEY_CASE_OPTIONS.CAMEL_CASE:
         return changeCaseObject.camelCase(body)
-      case BODY_FORMATTING_OPTIONS.SNAKE_CASE:
+      case BODY_KEY_CASE_OPTIONS.SNAKE_CASE:
         return changeCaseObject.snakeCase(body)
-      case BODY_FORMATTING_OPTIONS.PARAM_CASE:
+      case BODY_KEY_CASE_OPTIONS.PARAM_CASE:
         return changeCaseObject.paramCase(body)
       default:
         return body

--- a/src/index.js
+++ b/src/index.js
@@ -14,19 +14,19 @@ export default class Snuffles {
   constructor(
     baseUrl,
     defaultOptions = {},
-    bodyFormatting = BODY_FORMATTING_OPTIONS.SNAKE_CASE
+    bodyFormat = BODY_FORMATTING_OPTIONS.SNAKE_CASE
   ) {
     if (!baseUrl) {
       throw new Error('baseUrl has to be set')
     }
 
-    if (Object.values(BODY_FORMATTING_OPTIONS).indexOf(bodyFormatting) < 0) {
+    if (Object.values(BODY_FORMATTING_OPTIONS).indexOf(bodyFormat) < 0) {
       throw new Error('This formatting option is not allowed.')
     }
 
     this.baseUrl = baseUrl
     this.defaultOptions = defaultOptions
-    this.bodyFormatting = bodyFormatting
+    this.bodyFormat = bodyFormat
   }
 
   get(path, options = {}) {
@@ -98,7 +98,7 @@ export default class Snuffles {
   }
 
   formatBody(body) {
-    switch (this.bodyFormatting) {
+    switch (this.bodyFormat) {
       case BODY_FORMATTING_OPTIONS.CAMEL_CASE:
         return changeCaseObject.camelCase(body)
       case BODY_FORMATTING_OPTIONS.SNAKE_CASE:

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export default class Snuffles {
   constructor(
     baseUrl,
     defaultRequestOptions = {},
-    metaOptions = { ...defaultMetaOptions }
+    metaOptions = defaultMetaOptions
   ) {
     if (!baseUrl) {
       throw new Error('baseUrl has to be set')

--- a/src/test.js
+++ b/src/test.js
@@ -34,12 +34,12 @@ describe('snuffles', () => {
 
     it('sets the default body formatting', () => {
       const api = new Snuffles(baseUrl)
-      expect(api.bodyFormatting).toEqual('SNAKE_CASE')
+      expect(api.bodyFormat).toEqual('SNAKE_CASE')
     })
 
     it('sets the passed body formatting', () => {
       const api = new Snuffles(baseUrl, {}, 'CAMEL_CASE')
-      expect(api.bodyFormatting).toEqual('CAMEL_CASE')
+      expect(api.bodyFormat).toEqual('CAMEL_CASE')
     })
 
     it('does not set a forbidden body formatting', () => {

--- a/src/test.js
+++ b/src/test.js
@@ -34,12 +34,12 @@ describe('snuffles', () => {
 
     it('sets the default body formatting', () => {
       const api = new Snuffles(baseUrl)
-      expect(api.bodyFormat).toEqual('SNAKE_CASE')
+      expect(api.bodyKeyCase).toEqual('SNAKE_CASE')
     })
 
     it('sets the passed body formatting', () => {
       const api = new Snuffles(baseUrl, {}, 'CAMEL_CASE')
-      expect(api.bodyFormat).toEqual('CAMEL_CASE')
+      expect(api.bodyKeyCase).toEqual('CAMEL_CASE')
     })
 
     it('does not set a forbidden body formatting', () => {

--- a/src/test.js
+++ b/src/test.js
@@ -16,12 +16,11 @@ describe('snuffles', () => {
     })
 
     it('is valid without defaultOptions', () => {
-      const api = new Snuffles('http://www.example.com')
+      const api = new Snuffles(baseUrl)
       expect(api).toBeTruthy()
     })
 
     it('sets the baseUrl and default options', () => {
-      const baseUrl = 'http://www.example.com'
       const defaultOptions = {
         headers: {
           'X-AUTH-TOKEN': 'secret'
@@ -31,6 +30,20 @@ describe('snuffles', () => {
       const api = new Snuffles(baseUrl, defaultOptions)
       expect(api.baseUrl).toEqual(baseUrl)
       expect(api.defaultOptions).toEqual(defaultOptions)
+    })
+
+    it('sets the default body formatting', () => {
+      const api = new Snuffles(baseUrl)
+      expect(api.bodyFormatting).toEqual('SNAKE_CASE')
+    })
+
+    it('sets the passed body formatting', () => {
+      const api = new Snuffles(baseUrl, {}, 'CAMEL_CASE')
+      expect(api.bodyFormatting).toEqual('CAMEL_CASE')
+    })
+
+    it('does not set a forbidden body formatting', () => {
+      expect(() => new Snuffles(baseUrl, {}, 'SOME_CASE')).toThrow()
     })
   })
 
@@ -54,13 +67,10 @@ describe('snuffles', () => {
       let api
       beforeEach(() => {
         global.fetch.resetMocks()
-        api = new Snuffles(
-          baseUrl,
-          {
-            method: 'GET',
-            headers: { 'X-AUTH-TOKEN': 'token' }
-          }
-        )
+        api = new Snuffles(baseUrl, {
+          method: 'GET',
+          headers: { 'X-AUTH-TOKEN': 'token' }
+        })
       })
 
       it('makes a request to the given url', () => {
@@ -68,10 +78,7 @@ describe('snuffles', () => {
         api.request(requestPath)
 
         expect(global.fetch).toHaveBeenCalledTimes(1)
-        expect(global.fetch).toHaveBeenCalledWith(
-          requestUrl,
-          expect.anything()
-        )
+        expect(global.fetch).toHaveBeenCalledWith(requestUrl, expect.anything())
       })
 
       it('merges the passed options with the defaultOptions', () => {
@@ -93,7 +100,10 @@ describe('snuffles', () => {
         api.request(requestPath, options)
 
         expect(global.fetch).toHaveBeenCalledTimes(1)
-        expect(global.fetch).toHaveBeenCalledWith(requestUrl, expect.objectContaining(mergedOptions))
+        expect(global.fetch).toHaveBeenCalledWith(
+          requestUrl,
+          expect.objectContaining(mergedOptions)
+        )
       })
 
       it('merges the passed url with the baseUrl', () => {
@@ -127,10 +137,12 @@ describe('snuffles', () => {
       })
 
       it('returns the response body as a camelCased object', () => {
-        global.fetch.mockResponseOnce(JSON.stringify({
-          user_name: 'user',
-          secret_token: '123'
-        }))
+        global.fetch.mockResponseOnce(
+          JSON.stringify({
+            user_name: 'user',
+            secret_token: '123'
+          })
+        )
 
         api.request(requestPath).then(res => {
           expect(res).toMatchObject({
@@ -171,7 +183,9 @@ describe('snuffles', () => {
           api.request(requestPath, options)
 
           expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringMatching(/^.*\?([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?$/),
+            expect.stringMatching(
+              /^.*\?([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?$/
+            ),
             expect.anything()
           )
         })
@@ -186,49 +200,6 @@ describe('snuffles', () => {
           )
         })
       })
-    })
-  })
-
-  describe('wrappers', () => {
-    let api
-    beforeEach(() => {
-      global.fetch.resetMocks()
-      api = new Snuffles(baseUrl, { method: 'GET' })
-    })
-
-    it('get', () => {
-      api.request = jest.fn()
-
-      api.get(requestPath)
-      expect(api.request).toHaveBeenCalledTimes(1)
-    })
-
-    it('post', () => {
-      api.request = jest.fn()
-
-      api.post(requestPath)
-      expect(api.request).toHaveBeenCalledTimes(1)
-    })
-
-    it('put', () => {
-      api.request = jest.fn()
-
-      api.put(requestPath)
-      expect(api.request).toHaveBeenCalledTimes(1)
-    })
-
-    it('patch', () => {
-      api.request = jest.fn()
-
-      api.patch(requestPath)
-      expect(api.request).toHaveBeenCalledTimes(1)
-    })
-
-    it('delete', () => {
-      api.request = jest.fn()
-
-      api.delete(requestPath)
-      expect(api.request).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
Adds a new option, `bodyFormat`, to the Snuffles constructor. With this option, it is possible to defined in which format the request body should be sent out. Accepts all cases [change-case-object](https://github.com/BinaryThumb/change-case-object) supports (`snake_case`,`camelCase` and `param-case`).

Since this is an optional parameter and it defaults to `snake_case`, it is background compatible with earlier versions and can be released as a minor.