### PR TITLE
adds option to pass custom logger function (for HTTP logging)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "standard-react"
   ],
   "env": {
+    "browser": true,
     "es6": true
   },
   "plugins": [

--- a/README.md
+++ b/README.md
@@ -162,7 +162,29 @@ api.post('/users', options)
 
 ## Logging
 
-The library uses [debug](https://github.com/visionmedia/debug) for logging. Install the `debug` library in your project and add `snuffles:requests`, `snuffles:responses`, or `snuffles:*` (for both) to your debug namespaces config (e.g. `DEBUG=snuffles:*`) in order to see Snuffles log entries appear in your logs. If the logs should get stored anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, etc.
+For normal browser-based development the network tab in your browser's developer tools is probably all you need.
+
+If you should have custom logging requirements (e.g. if you work with React Native, where you cannot use the network tab in the remote React Native Debugger) you can pass in your custom logger function as an option to the 3rd argument of `Snuffles()`.
+
+Here is an example using the [debug](https://github.com/visionmedia/debug) library:
+
+```
+import createDebug from 'debug'
+const debug = createDebug('api')
+
+const apiClient = new Snuffles(
+  apiUrl,
+  { ... }
+  { logger: debug }
+)
+```
+
+The first argument of each log call is always the `type` of the log entry (either `'request'` or `'response'`), so you can use this to log them differently.  E.g. into separate logging namespaces:
+```
+{ logger: (type, ...data) => createDebug('api:${type}')(data) }
+```
+
+If the logs should get persisted/streamed to anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, which are part of the logged HTTP requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For normal browser-based development the network tab in your browser's developer
 
 If you should have custom logging requirements (e.g. if you work with React Native, where you cannot use the network tab in the remote React Native Debugger) you can pass in your custom logger function as an option to the 3rd argument of the `Snuffles()` constructor.
 
-Here is an example using the [debug](https://github.com/visionmedia/debug) as a custom logger:
+Here is an example using [debug](https://github.com/visionmedia/debug) as a custom logger:
 
 ```
 import createDebug from 'debug'

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ api.post('/users', options)
 
 For normal browser-based development the network tab in your browser's developer tools is probably all you need.
 
-If you should have custom logging requirements (e.g. if you work with React Native, where you cannot use the network tab in the remote React Native Debugger) you can pass in your custom logger function as an option to the 3rd argument of `Snuffles()`.
+If you should have custom logging requirements (e.g. if you work with React Native, where you cannot use the network tab in the remote React Native Debugger) you can pass in your custom logger function as an option to the 3rd argument of the `Snuffles()` constructor.
 
-Here is an example using the [debug](https://github.com/visionmedia/debug) library:
+Here is an example using the [debug](https://github.com/visionmedia/debug) as a custom logger:
 
 ```
 import createDebug from 'debug'
@@ -179,12 +179,12 @@ const apiClient = new Snuffles(
 )
 ```
 
-The first argument of each log call is always the `type` of the log entry (either `'request'` or `'response'`), so you can use this to log them differently.  E.g. into separate logging namespaces:
+The first argument of each log call is always the `type` of the log entry (either `'request'` or `'response'`), so you can take advantage of this to log them differently.  E.g. into separate logging namespaces:
 ```
 { logger: (type, ...data) => createDebug('api:${type}')(data) }
 ```
 
-If the logs should get persisted/streamed to anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, which are part of the logged HTTP requests.
+Beware: if the logs should get persisted/streamed to anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, which are part of the logged HTTP requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const apiClient = new Snuffles(
 
 The first argument of each log call is always the `type` of the log entry (either `'request'` or `'response'`), so you can take advantage of this to log them differently.  E.g. into separate logging namespaces:
 ```
-{ logger: (type, ...data) => createDebug('api:${type}')(data) }
+{ logger: (type, ...data) => createDebug('api:${type}')(...data) }
 ```
 
 Beware: if the logs should get persisted/streamed to anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, which are part of the logged HTTP requests.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ api.post('/users', options)
 // }
 ```
 
+## Logging
+
+The library uses [debug](https://github.com/visionmedia/debug) for logging. Install the `debug` library in your project and add `snuffles:requests`, `snuffles:responses`, or `snuffles:*` (for both) to your debug namespaces config (e.g. `DEBUG=snuffles:*`) in order to see Snuffles log entries appear in your logs. If the logs should get stored anywhere, be careful that you could be exposing sensitive information like passwords, API tokens, etc.
+
 ## License
 
 MIT © [railslove](https://github.com/railslove)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   ],
   "dependencies": {
     "change-case-object": "2.0.0",
-    "debug": "^4.1.0",
     "deepmerge": "2.2.1",
     "query-string": "4.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "dist"
   ],
   "dependencies": {
-    "deepmerge": "2.2.1",
     "change-case-object": "2.0.0",
+    "debug": "^4.1.0",
+    "deepmerge": "2.2.1",
     "query-string": "4.1.0"
   }
 }

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -6,11 +6,8 @@ const BODY_KEY_CASE_OPTIONS = {
   PARAM_CASE: changeCaseObject.paramCase
 }
 
-const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE' }
-
 export default class MetaOptions {
   constructor(options) {
-    options = {...defaultMetaOptions, ...options}
     if (!this.isValidBodyKeyCase(options.bodyKeyCase)) {
       throw new Error('This body key formatting option is not allowed.')
     }

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -13,15 +13,18 @@ export default class MetaOptions {
     }
     this.bodyKeyCase = options.bodyKeyCase
 
-    if (typeof options.logger === 'function') {
-      this.logger = options.logger
-    } else {
-      this.logger = () => {} // no-op logger
+    if (!this.isValidLogger(options.logger)) {
+      throw new Error('The provided logger is not a function.')
     }
+    this.logger = options.logger
   }
 
   isValidBodyKeyCase(bodyKeyCase) {
-    return Object.keys(BODY_KEY_CASE_OPTIONS).includes(bodyKeyCase)
+    return bodyKeyCase && Object.keys(BODY_KEY_CASE_OPTIONS).includes(bodyKeyCase)
+  }
+
+  isValidLogger(logger) {
+    return typeof logger === 'function'
   }
 
   getBodyKeyConverter() {

--- a/src/MetaOptions.js
+++ b/src/MetaOptions.js
@@ -6,17 +6,20 @@ const BODY_KEY_CASE_OPTIONS = {
   PARAM_CASE: changeCaseObject.paramCase
 }
 
+const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE' }
+
 export default class MetaOptions {
   constructor(options) {
-    if (options.bodyKeyCase && !this.isValidBodyKeyCase(options.bodyKeyCase)) {
+    options = {...defaultMetaOptions, ...options}
+    if (!this.isValidBodyKeyCase(options.bodyKeyCase)) {
       throw new Error('This body key formatting option is not allowed.')
     }
-
     this.bodyKeyCase = options.bodyKeyCase
+
     if (typeof options.logger === 'function') {
       this.logger = options.logger
     } else {
-      this.logger = () => {} // noop logger
+      this.logger = () => {} // no-op logger
     }
   }
 

--- a/src/__tests__/MetaOptions.js
+++ b/src/__tests__/MetaOptions.js
@@ -3,7 +3,7 @@ import MetaOptions from '../MetaOptions'
 describe('MetaOptions', () => {
   describe('Initialisation', () => {
     it('is valid with a valida options object', () => {
-      const options = { bodyKeyCase: 'SNAKE_CASE' }
+      const options = { bodyKeyCase: 'SNAKE_CASE', logger: () => {} }
       const metaOptions = new MetaOptions(options)
       expect(metaOptions).toBeTruthy()
     })
@@ -18,6 +18,11 @@ describe('MetaOptions', () => {
 
     it('throws an error if bodyKeyCase is not valid', () => {
       const options = { bodyKeyCase: 'INVALID' }
+      expect(() => new MetaOptions(options)).toThrow()
+    })
+
+    it('throws an error if logger is not valid', () => {
+      const options = { bodyKeyCase: 'INVALID', logger: 'iamnotalogger' }
       expect(() => new MetaOptions(options)).toThrow()
     })
   })

--- a/src/__tests__/MetaOptions.js
+++ b/src/__tests__/MetaOptions.js
@@ -8,14 +8,6 @@ describe('MetaOptions', () => {
       expect(metaOptions).toBeTruthy()
     })
 
-    it('throws an error if no options are passed', () => {
-      expect(() => new MetaOptions()).toThrow()
-    })
-
-    it('throws an error if bodyKeyCase is not present in the options', () => {
-      expect(() => new MetaOptions({})).toThrow()
-    })
-
     it('throws an error if bodyKeyCase is not valid', () => {
       const options = { bodyKeyCase: 'INVALID' }
       expect(() => new MetaOptions(options)).toThrow()

--- a/src/__tests__/MetaOptions.js
+++ b/src/__tests__/MetaOptions.js
@@ -8,6 +8,14 @@ describe('MetaOptions', () => {
       expect(metaOptions).toBeTruthy()
     })
 
+    it('throws an error if no options are passed', () => {
+      expect(() => new MetaOptions()).toThrow()
+    })
+
+    it('throws an error if bodyKeyCase is not present in the options', () => {
+      expect(() => new MetaOptions({})).toThrow()
+    })
+
     it('throws an error if bodyKeyCase is not valid', () => {
       const options = { bodyKeyCase: 'INVALID' }
       expect(() => new MetaOptions(options)).toThrow()

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -54,7 +54,6 @@ describe('snuffles', () => {
       let api
 
       beforeEach(() => {
-        global.fetch.resetMocks()
         api = new Snuffles(baseUrl)
       })
 
@@ -68,7 +67,6 @@ describe('snuffles', () => {
     describe('with defaults', () => {
       let api
       beforeEach(() => {
-        global.fetch.resetMocks()
         api = new Snuffles(baseUrl, {
           method: 'GET',
           headers: { 'X-AUTH-TOKEN': 'token' }
@@ -200,6 +198,40 @@ describe('snuffles', () => {
             expect.stringContaining('name=sirius', 'animal=dog'),
             expect.anything()
           )
+        })
+      })
+    })
+
+    describe('with logger', () => {
+      it('should call the logger with the requst and response infos', () => {
+        global.fetch.mockResponseOnce(JSON.stringify({}))
+
+        const mockLogger = jest.fn()
+
+        const api = new Snuffles(baseUrl, {
+          method: 'GET',
+          headers: { 'X-AUTH-TOKEN': 'token' }
+        }, { logger: mockLogger })
+
+        api.request(requestPath).then(() => {
+          expect(mockLogger.mock.calls).toEqual([
+            [
+              'request',
+              'http://example.com/users',
+              {
+                headers: { 'X-AUTH-TOKEN': 'token' },
+                method: 'GET'
+              }
+            ],
+            [
+              'response',
+              {
+                body: {},
+                headers: { 'content-type': 'text/plain;charset=UTF-8' },
+                status: 200
+              }
+            ]
+          ])
         })
       })
     })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -203,35 +203,76 @@ describe('snuffles', () => {
     })
 
     describe('with logger', () => {
-      it('should call the logger with the requst and response infos', () => {
-        global.fetch.mockResponseOnce(JSON.stringify({}))
+      describe('single logger', () => {
+        it('should call the logger with the requst and response infos', () => {
+          global.fetch.mockResponseOnce(JSON.stringify({}))
 
-        const mockLogger = jest.fn()
+          const mockLogger = jest.fn()
 
-        const api = new Snuffles(baseUrl, {
-          method: 'GET',
-          headers: { 'X-AUTH-TOKEN': 'token' }
-        }, { logger: mockLogger })
+          const api = new Snuffles(baseUrl, {
+            method: 'GET',
+            headers: { 'X-AUTH-TOKEN': 'token' }
+          }, { logger: mockLogger })
 
-        api.request(requestPath).then(() => {
-          expect(mockLogger.mock.calls).toEqual([
-            [
-              'request',
+          api.request(requestPath).then(() => {
+            expect(mockLogger.mock.calls).toEqual([
+              [
+                'request',
+                'http://example.com/users',
+                {
+                  headers: { 'X-AUTH-TOKEN': 'token' },
+                  method: 'GET'
+                }
+              ],
+              [
+                'response',
+                {
+                  body: {},
+                  headers: { 'content-type': 'text/plain;charset=UTF-8' },
+                  status: 200
+                }
+              ]
+            ])
+          })
+        })
+      })
+
+      describe('2 separate loggers', () => {
+        it('should call the individual loggers with the requst and response infos', () => {
+          global.fetch.mockResponseOnce(JSON.stringify({}))
+
+          const mockLoggers = {
+            request: jest.fn(),
+            response: jest.fn()
+          }
+
+          const api = new Snuffles(
+            baseUrl,
+            {
+              method: 'GET',
+              headers: { 'X-AUTH-TOKEN': 'token' }
+            },
+            {
+              logger: (type, ...data) => mockLoggers[type](...data)
+            }
+          )
+
+          api.request(requestPath).then(() => {
+            expect(mockLoggers.request).toHaveBeenCalledWith(
               'http://example.com/users',
               {
                 headers: { 'X-AUTH-TOKEN': 'token' },
                 method: 'GET'
               }
-            ],
-            [
-              'response',
+            )
+            expect(mockLoggers.response).toHaveBeenCalledWith(
               {
                 body: {},
                 headers: { 'content-type': 'text/plain;charset=UTF-8' },
                 status: 200
               }
-            ]
-          ])
+            )
+          })
         })
       })
     })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -44,7 +44,8 @@ describe('snuffles', () => {
     })
 
     it('does not set a forbidden body formatting', () => {
-      expect(() => new Snuffles(baseUrl, {}, 'SOME_CASE')).toThrow()
+      const metaOptions = { bodyKeyCase: 'SOME_CASE' }
+      expect(() => new Snuffles(baseUrl, {}, metaOptions)).toThrow()
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,11 @@ import merge from 'deepmerge'
 
 const ALLOWED_REQUEST_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
 
-const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE' }
-
 export default class Snuffles {
   constructor(
     baseUrl,
     defaultRequestOptions = {},
-    metaOptions = defaultMetaOptions
+    metaOptions = {}
   ) {
     if (!baseUrl) {
       throw new Error('baseUrl has to be set')
@@ -20,7 +18,7 @@ export default class Snuffles {
     this.baseUrl = baseUrl
     this.defaultRequestOptions = defaultRequestOptions
     this.metaOptions = new MetaOptions(metaOptions)
-    this.log = metaOptions.logger
+    this.log = this.metaOptions.logger
   }
 
   get(path, options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import changeCaseObject from 'change-case-object'
 import qs from 'query-string'
 import merge from 'deepmerge'
+import createDebug from 'debug'
+
+const requestDebug = createDebug('snuffles:requests')
+const responseDebug = createDebug('snuffles:responses')
 
 const ALLOWED_REQUEST_METHODS = [
   'GET',
@@ -72,12 +76,15 @@ export default class Snuffles {
       requestOptions.body = JSON.stringify(snakeCasedBody)
     }
 
-    return fetch(`${url}${queryString}`, {
+    const urlWithQueryString = `${url}${queryString}`
+    requestDebug(urlWithQueryString, requestOptions)
+    return fetch(urlWithQueryString, {
       ...requestOptions
     })
       .then(res => {
         if (!res.ok) {
           const error = new Error('API response was not ok.')
+          responseDebug({...res, error})
           error.response = res
           throw error
         }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import merge from 'deepmerge'
 
 const ALLOWED_REQUEST_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
 
-const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE' }
+const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE', logger: () => {} }
 
 export default class Snuffles {
   constructor(

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export default class Snuffles {
     }
 
     const urlWithQueryString = `${url}${queryString}`
-    this.log(urlWithQueryString, requestOptions)
+    this.log('request', urlWithQueryString, requestOptions)
     return fetch(urlWithQueryString, {
       ...requestOptions
     })
@@ -103,7 +103,7 @@ export default class Snuffles {
       )
       .then(parsedResponse => {
         parsedResponse.body = changeCaseObject.camelCase(parsedResponse.body)
-        this.log('response:', parsedResponse)
+        this.log('response', parsedResponse)
         return parsedResponse.body
       })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import merge from 'deepmerge'
 
 const ALLOWED_REQUEST_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
 
+const defaultMetaOptions = { bodyKeyCase: 'SNAKE_CASE' }
+
 export default class Snuffles {
   constructor(
     baseUrl,
@@ -17,7 +19,7 @@ export default class Snuffles {
 
     this.baseUrl = baseUrl
     this.defaultRequestOptions = defaultRequestOptions
-    this.metaOptions = new MetaOptions(metaOptions)
+    this.metaOptions = new MetaOptions({...defaultMetaOptions, ...metaOptions})
     this.log = this.metaOptions.logger
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,10 @@ export default class Snuffles {
         return res
       })
       .then(res => res.json())
-      .then(json => changeCaseObject.camelCase(json))
+      .then(json => {
+        const casedResponse = changeCaseObject.camelCase(json)
+        responseDebug(casedResponse)
+        return casedResponse
+      })
   }
 }


### PR DESCRIPTION
potential TODOs:
* [x] we are currently not logging response headers at all
* [x] in case of a successful response, we are only logging the response body (not even the response status)
* [x] tests