### PR TITLE
Remove unnecessary peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
     "start": "rollup -c -w",
     "prepare": "npm run build"
   },
-  "peerDependencies": {
-    "prop-types": "15.5.4",
-    "react": "^5.0.0 || 16.0.0",
-    "react-dom": "15.0.0 || 16.0.0"
-  },
   "devDependencies": {
     "babel-core": "6.26.3",
     "babel-eslint": "8.2.5",


### PR DESCRIPTION
The peerDependencies are from `create-react-library`, but they aren't required for snuffles.