### PR TITLE
fixes bug with logging an error response

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -237,6 +237,35 @@ describe('snuffles', () => {
             ])
           })
         })
+
+        it('should log an error response', () => {
+          global.fetch.mockResponseOnce(JSON.stringify({}), { status: 404 })
+
+          const mockLogger = jest.fn()
+
+          const api = new Snuffles(baseUrl, {
+            method: 'GET',
+            headers: { 'X-AUTH-TOKEN': 'token' }
+          }, { logger: mockLogger })
+
+          api.request(requestPath).catch(() => {
+            expect(mockLogger.mock.calls).toEqual([
+              [
+                'request',
+                'http://example.com/users',
+                {
+                  headers: { 'X-AUTH-TOKEN': 'token' },
+                  method: 'GET'
+                }
+              ],
+              [
+                'response',
+                'Error: API response was not ok.',
+                expect.any(Response)
+              ]
+            ])
+          })
+        })
       })
 
       describe('2 separate loggers', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ export default class Snuffles {
       .then(res => {
         if (!res.ok) {
           const error = new Error('API response was not ok.')
-          this.log({...res, error})
+          this.log('response', error.toString(), res)
           error.response = res
           throw error
         }


### PR DESCRIPTION
trying to merge the resopnse object into the logged object with the spread operator `{...res,` resulted in this error:

```
TypeError: One of the sources for assign has an enumerable key on the prototype chain. Are you trying to assign a prototype property? We don't allow it, as this is an edge case that we do not support. This error is a performance optimization and not spec compliant.
```