### PR TITLE
Wrap parsing of request body in try/catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,18 +95,17 @@ export default class Snuffles {
 
         return res
       })
-      .then(res => {
+      .then(async res => {
         const { status } = res
         const resultBase = { status, headers: res.headers, body: {} }
 
-        const contentLength = res.headers['map']['content-length']
-        const contentType = res.headers['map']['content-type']
-
-        if (contentLength <= 1 || contentType !== 'application/json') {
-          return resultBase
+        try {
+          const parsedRes = await res.json()
+          resultBase.body = parsedRes
+        } catch (error) {
+          resultBase.body = {}
         }
-
-        return res.json().then(json => ({ ...resultBase, body: json }))
+        return resultBase
       })
       .then(parsedResponse => {
         parsedResponse.body = changeCaseObject.camelCase(parsedResponse.body)


### PR DESCRIPTION
This will remove our dependency on the Headers object completely, which
is not supported by iOS Safari at all.

However, with the current solution, a lot of errors are simply swallowed
and an empy body is returned, which could cause some false flags during
development of applications.

We should think about restructuring the whole request method in the future, which could also mean a major version release.

Related to #20 and #21 